### PR TITLE
Feature: Collapsible JSON viewer with cursor navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,16 @@
 import { Box, useApp, useInput } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CollapsibleJsonViewer } from "./components/CollapsibleJsonViewer";
-import { DebugBar } from "./components/DebugBar";
-import { JsonViewer } from "./components/JsonViewer";
-import { SchemaViewer } from "./components/SchemaViewer";
-import { SearchBar } from "./components/SearchBar";
-import { StatusBar } from "./components/StatusBar";
-import type { AppProps } from "./types/app";
-import type { NavigationAction } from "./types/collapsible";
-import type { SearchState } from "./types/index";
-import { formatJsonSchema, inferJsonSchema } from "./utils/schemaUtils";
-import { searchInJson, searchInJsonSchema } from "./utils/searchUtils";
+import { CollapsibleJsonViewer } from "./components/CollapsibleJsonViewer.js";
+import { DebugBar } from "./components/DebugBar.js";
+import { JsonViewer } from "./components/JsonViewer.js";
+import { SchemaViewer } from "./components/SchemaViewer.js";
+import { SearchBar } from "./components/SearchBar.js";
+import { StatusBar } from "./components/StatusBar.js";
+import type { AppProps } from "./types/app.js";
+import type { NavigationAction } from "./types/collapsible.js";
+import type { SearchState } from "./types/index.js";
+import { formatJsonSchema, inferJsonSchema } from "./utils/schemaUtils.js";
+import { searchInJson, searchInJsonSchema } from "./utils/searchUtils.js";
 
 /**
  * Main application component for the JSON TUI Viewer

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -313,6 +313,7 @@ export function App({
         ctrl?: boolean;
         meta?: boolean;
         escape?: boolean;
+        return?: boolean;
       },
     ) => {
       if (input === "s" && !key.ctrl && !key.meta) {

--- a/src/components/CollapsibleJsonViewer.tsx
+++ b/src/components/CollapsibleJsonViewer.tsx
@@ -220,6 +220,8 @@ export const CollapsibleJsonViewer = forwardRef<
           const globalLineIndex = startLine + index;
           const uniqueKey = `collapsible-line-${globalLineIndex}`;
 
+          if (!node) return null;
+
           return (
             <Box key={uniqueKey} flexDirection="row">
               {showLineNumbers && (

--- a/src/components/CollapsibleJsonViewer.tsx
+++ b/src/components/CollapsibleJsonViewer.tsx
@@ -7,17 +7,20 @@ import {
   useMemo,
   useState,
 } from "react";
-import type { CollapsibleState, NavigationAction } from "../types/collapsible";
-import type { JsonValue, SearchResult } from "../types/index";
+import type {
+  CollapsibleState,
+  NavigationAction,
+} from "../types/collapsible.js";
+import type { JsonValue, SearchResult } from "../types/index.js";
 import {
   getNodeDisplayText,
   handleNavigation,
   initializeCollapsibleState,
-} from "../utils/collapsibleJson";
+} from "../utils/collapsibleJson.js";
 import {
   applySearchHighlighting,
   tokenizeLine,
-} from "../utils/syntaxHighlight";
+} from "../utils/syntaxHighlight.js";
 
 interface CollapsibleJsonViewerProps {
   data: JsonValue;
@@ -239,18 +242,3 @@ export const CollapsibleJsonViewer = forwardRef<
     </Box>
   );
 });
-
-// Helper function to check if a node can be toggled
-export function canToggleNode(
-  state: CollapsibleState,
-  nodeId: string,
-): boolean {
-  const node = state.nodes.get(nodeId);
-  return node ? node.isCollapsible : false;
-}
-
-// Helper function to get current cursor node
-export function getCurrentCursorNode(state: CollapsibleState) {
-  if (!state.cursorPosition) return null;
-  return state.nodes.get(state.cursorPosition.nodeId) || null;
-}

--- a/src/components/CollapsibleJsonViewer.tsx
+++ b/src/components/CollapsibleJsonViewer.tsx
@@ -1,0 +1,254 @@
+import { Box, Text } from "ink";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from "react";
+import type { CollapsibleState, NavigationAction } from "../types/collapsible";
+import type { JsonValue, SearchResult } from "../types/index";
+import {
+  getNodeDisplayText,
+  handleNavigation,
+  initializeCollapsibleState,
+} from "../utils/collapsibleJson";
+import {
+  applySearchHighlighting,
+  tokenizeLine,
+} from "../utils/syntaxHighlight";
+
+interface CollapsibleJsonViewerProps {
+  data: JsonValue;
+  scrollOffset?: number;
+  searchTerm?: string;
+  searchResults?: SearchResult[];
+  currentSearchIndex?: number;
+  visibleLines?: number;
+  showLineNumbers?: boolean;
+  onNavigate?: (action: NavigationAction) => void;
+}
+
+export const CollapsibleJsonViewer = forwardRef<
+  { navigate: (action: NavigationAction) => void },
+  CollapsibleJsonViewerProps
+>(function CollapsibleJsonViewer(
+  {
+    data,
+    scrollOffset = 0,
+    searchTerm = "",
+    searchResults = [],
+    currentSearchIndex = 0,
+    visibleLines,
+    showLineNumbers = false,
+    onNavigate,
+  },
+  ref,
+) {
+  const [collapsibleState, setCollapsibleState] = useState<CollapsibleState>(
+    () => initializeCollapsibleState(data),
+  );
+
+  // Update state when data changes
+  useEffect(() => {
+    setCollapsibleState(initializeCollapsibleState(data));
+  }, [data]);
+
+  // Calculate visible lines
+  const effectiveVisibleLines =
+    visibleLines || Math.max(1, (process.stdout.rows || 24) - 3);
+
+  // Get the display lines from flattened nodes
+  const displayLines = useMemo(() => {
+    return collapsibleState.flattenedNodes.map((node) => {
+      const isExpanded = collapsibleState.expandedNodes.has(node.id);
+      return getNodeDisplayText(node, isExpanded);
+    });
+  }, [collapsibleState.flattenedNodes, collapsibleState.expandedNodes]);
+
+  // Calculate which lines to display based on scroll offset
+  const startLine = scrollOffset;
+  const endLine = Math.min(
+    displayLines.length,
+    startLine + effectiveVisibleLines,
+  );
+  const visibleLineData = displayLines.slice(startLine, endLine);
+  const visibleNodes = collapsibleState.flattenedNodes.slice(
+    startLine,
+    endLine,
+  );
+
+  // Calculate line number width
+  const totalLines = displayLines.length;
+  const lineNumberWidth = totalLines.toString().length;
+
+  const formatLineNumber = (lineIndex: number): string => {
+    const lineNumber = lineIndex + 1;
+    return lineNumber.toString().padStart(lineNumberWidth, " ");
+  };
+
+  // Handle navigation actions
+  const handleNavigationAction = useCallback(
+    (action: NavigationAction) => {
+      const result = handleNavigation(collapsibleState, action);
+      setCollapsibleState(result.newState);
+
+      if (onNavigate) {
+        onNavigate(action);
+      }
+    },
+    [collapsibleState, onNavigate],
+  );
+
+  // Create search results map for O(1) lookup
+  const searchResultsByLine = useMemo(() => {
+    const map = new Map<number, SearchResult[]>();
+    searchResults.forEach((result) => {
+      if (!map.has(result.lineIndex)) {
+        map.set(result.lineIndex, []);
+      }
+      map.get(result.lineIndex)?.push(result);
+    });
+    return map;
+  }, [searchResults]);
+
+  // Render line with combined syntax and search highlighting
+  const renderLineWithHighlighting = useCallback(
+    (
+      line: string,
+      originalIndex: number,
+      node: (typeof visibleNodes)[0],
+      searchTerm: string,
+      isCurrentResult: boolean,
+    ) => {
+      // Check if this is the cursor line
+      const isCursorLine = collapsibleState.cursorPosition?.nodeId === node.id;
+
+      // First tokenize the line for syntax highlighting
+      const syntaxTokens = tokenizeLine(line, "");
+
+      // Then apply search highlighting to the tokens
+      const highlightedTokens = applySearchHighlighting(
+        syntaxTokens,
+        searchTerm,
+        isCurrentResult,
+      );
+
+      // Render the tokens with cursor highlighting
+      return (
+        <Text
+          key={originalIndex}
+          {...(isCurrentResult ? { backgroundColor: "blue" } : {})}
+          {...(isCursorLine && !isCurrentResult
+            ? { backgroundColor: "gray", dimColor: true }
+            : {})}
+        >
+          {highlightedTokens.map((token, tokenIndex) => {
+            const key = `${originalIndex}-${tokenIndex}-${token.text}`;
+
+            if (token.isMatch) {
+              return (
+                <Text
+                  key={key}
+                  color={token.color}
+                  backgroundColor={isCurrentResult ? "magenta" : "yellow"}
+                  bold={isCurrentResult}
+                >
+                  {token.text}
+                </Text>
+              );
+            } else {
+              return (
+                <Text key={key} color={token.color}>
+                  {token.text}
+                </Text>
+              );
+            }
+          })}
+        </Text>
+      );
+    },
+    [collapsibleState.cursorPosition],
+  );
+
+  const renderLine = useCallback(
+    (line: string, originalIndex: number, node: (typeof visibleNodes)[0]) => {
+      const globalLineIndex = startLine + originalIndex;
+
+      // Check if this line has search results
+      const lineSearchResults = searchResultsByLine.get(globalLineIndex) || [];
+      const hasSearchHighlight = searchTerm && lineSearchResults.length > 0;
+      const isCurrentSearchResult =
+        searchResults.length > 0 &&
+        searchResults[currentSearchIndex]?.lineIndex === globalLineIndex;
+
+      // Use the new token-based rendering approach
+      return renderLineWithHighlighting(
+        line,
+        globalLineIndex,
+        node,
+        hasSearchHighlight ? searchTerm : "",
+        isCurrentSearchResult,
+      );
+    },
+    [
+      startLine,
+      searchResultsByLine,
+      searchTerm,
+      searchResults,
+      currentSearchIndex,
+      renderLineWithHighlighting,
+    ],
+  );
+
+  // Expose navigation methods for parent components via ref
+  useImperativeHandle(
+    ref,
+    () => ({
+      navigate: handleNavigationAction,
+    }),
+    [handleNavigationAction],
+  );
+
+  return (
+    <Box flexGrow={1} flexDirection="column" padding={1}>
+      <Box flexDirection="column">
+        {visibleLineData.map((line, index) => {
+          const originalIndex = index;
+          const node = visibleNodes[index];
+          const globalLineIndex = startLine + index;
+          const uniqueKey = `collapsible-line-${globalLineIndex}`;
+
+          return (
+            <Box key={uniqueKey} flexDirection="row">
+              {showLineNumbers && (
+                <Box marginRight={1}>
+                  <Text color="gray" dimColor>
+                    {formatLineNumber(globalLineIndex)}
+                  </Text>
+                </Box>
+              )}
+              <Box flexGrow={1}>{renderLine(line, originalIndex, node)}</Box>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+});
+
+// Helper function to check if a node can be toggled
+export function canToggleNode(
+  state: CollapsibleState,
+  nodeId: string,
+): boolean {
+  const node = state.nodes.get(nodeId);
+  return node ? node.isCollapsible : false;
+}
+
+// Helper function to get current cursor node
+export function getCurrentCursorNode(state: CollapsibleState) {
+  if (!state.cursorPosition) return null;
+  return state.nodes.get(state.cursorPosition.nodeId) || null;
+}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -3,16 +3,25 @@ import { Box, Text } from "ink";
 interface StatusBarProps {
   error: string | null;
   keyboardEnabled?: boolean;
+  collapsibleMode?: boolean;
 }
 
-export function StatusBar({ error, keyboardEnabled = false }: StatusBarProps) {
+export function StatusBar({
+  error,
+  keyboardEnabled = false,
+  collapsibleMode = false,
+}: StatusBarProps) {
   const getStatusMessage = () => {
     if (error) {
       return `Error: ${error}`;
     }
 
     if (keyboardEnabled) {
-      return `JSON TUI Viewer - q: Quit/Search input | Ctrl+C: Exit | j/k: Line | Ctrl+f/b: Half-page | gg/G: Top/Bottom | s: Search | Esc: Exit search | D: Toggle debug | L: Toggle line numbers | S: Toggle schema`;
+      if (collapsibleMode) {
+        return `JSON TUI Viewer (Collapsible) - q: Quit | Ctrl+C: Exit | j/k: Move cursor | Enter: Toggle expand/collapse | s: Search | C: Toggle collapsible mode | D: Debug | L: Line numbers | S: Schema`;
+      } else {
+        return `JSON TUI Viewer - q: Quit/Search input | Ctrl+C: Exit | j/k: Line | Ctrl+f/b: Half-page | gg/G: Top/Bottom | s: Search | Esc: Exit search | D: Toggle debug | L: Toggle line numbers | S: Toggle schema | C: Toggle collapsible`;
+      }
     } else {
       return `JSON TUI Viewer - Keyboard input not available (try: jsont < file.json in terminal)`;
     }

--- a/src/types/collapsible.ts
+++ b/src/types/collapsible.ts
@@ -1,0 +1,48 @@
+/**
+ * Types for collapsible JSON viewer functionality
+ */
+
+import type { JsonValue } from "./index";
+
+export interface JsonPath {
+  type: "root" | "object" | "array";
+  key?: string | number;
+  path: (string | number)[];
+}
+
+export interface JsonNode {
+  id: string; // Unique identifier for the node
+  path: JsonPath;
+  value: JsonValue;
+  type: "object" | "array" | "primitive";
+  level: number; // Nesting level for indentation
+  isCollapsible: boolean; // Whether this node can be collapsed
+  isCollapsed: boolean; // Whether this node is currently collapsed
+  children?: JsonNode[];
+  parent?: JsonNode;
+}
+
+export interface CursorPosition {
+  nodeId: string;
+  lineIndex: number; // Which line on screen this cursor is on
+}
+
+export interface CollapsibleState {
+  nodes: Map<string, JsonNode>; // All nodes indexed by ID
+  expandedNodes: Set<string>; // IDs of expanded nodes
+  cursorPosition: CursorPosition | null;
+  flattenedNodes: JsonNode[]; // Current visible nodes in display order
+}
+
+export interface NavigationAction {
+  type: "move_up" | "move_down" | "toggle_node" | "expand_all" | "collapse_all";
+  nodeId?: string;
+}
+
+/**
+ * Result of a navigation action
+ */
+export interface NavigationResult {
+  newState: CollapsibleState;
+  scrollToLine?: number; // Line to scroll to if cursor moved off screen
+}

--- a/src/types/collapsible.ts
+++ b/src/types/collapsible.ts
@@ -2,7 +2,7 @@
  * Types for collapsible JSON viewer functionality
  */
 
-import type { JsonValue } from "./index";
+import type { JsonValue } from "./index.js";
 
 export interface JsonPath {
   type: "root" | "object" | "array";

--- a/src/utils/collapsibleJson.spec.ts
+++ b/src/utils/collapsibleJson.spec.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildJsonTree,
+  flattenNodes,
+  formatCollapsedNode,
+  generateNodeId,
+  getNodeDisplayText,
+  getValueType,
+  handleNavigation,
+  initializeCollapsibleState,
+  isCollapsible,
+} from "./collapsibleJson";
+
+describe("collapsibleJson", () => {
+  const testData = {
+    name: "John",
+    age: 30,
+    address: {
+      street: "123 Main St",
+      city: "New York",
+    },
+    hobbies: ["reading", "coding"],
+  };
+
+  describe("generateNodeId", () => {
+    it("should generate correct node IDs", () => {
+      expect(generateNodeId([])).toBe("root");
+      expect(generateNodeId(["name"])).toBe("name");
+      expect(generateNodeId(["address", "street"])).toBe("address.street");
+    });
+  });
+
+  describe("getValueType", () => {
+    it("should correctly identify value types", () => {
+      expect(getValueType("string")).toBe("primitive");
+      expect(getValueType(123)).toBe("primitive");
+      expect(getValueType(null)).toBe("primitive");
+      expect(getValueType({})).toBe("object");
+      expect(getValueType([])).toBe("array");
+    });
+  });
+
+  describe("isCollapsible", () => {
+    it("should correctly identify collapsible values", () => {
+      expect(isCollapsible("string")).toBe(false);
+      expect(isCollapsible(123)).toBe(false);
+      expect(isCollapsible({})).toBe(false); // empty object
+      expect(isCollapsible([])).toBe(false); // empty array
+      expect(isCollapsible({ key: "value" })).toBe(true);
+      expect(isCollapsible(["item"])).toBe(true);
+    });
+  });
+
+  describe("buildJsonTree", () => {
+    it("should build correct tree structure", () => {
+      const tree = buildJsonTree(testData);
+
+      expect(tree.id).toBe("root");
+      expect(tree.type).toBe("object");
+      expect(tree.isCollapsible).toBe(true);
+      expect(tree.children).toHaveLength(4);
+
+      // Check name property
+      const nameNode = tree.children?.find(
+        (child) => child.path.key === "name",
+      );
+      expect(nameNode?.type).toBe("primitive");
+      expect(nameNode?.value).toBe("John");
+      expect(nameNode?.isCollapsible).toBe(false);
+
+      // Check address property
+      const addressNode = tree.children?.find(
+        (child) => child.path.key === "address",
+      );
+      expect(addressNode?.type).toBe("object");
+      expect(addressNode?.isCollapsible).toBe(true);
+      expect(addressNode?.children).toHaveLength(2);
+    });
+  });
+
+  describe("initializeCollapsibleState", () => {
+    it("should initialize state with all nodes expanded", () => {
+      const state = initializeCollapsibleState(testData);
+
+      expect(state.nodes.size).toBeGreaterThan(1);
+      expect(state.expandedNodes.size).toBeGreaterThan(0);
+      expect(state.cursorPosition).not.toBeNull();
+      expect(state.flattenedNodes.length).toBeGreaterThan(1);
+    });
+  });
+
+  describe("flattenNodes", () => {
+    it("should flatten expanded nodes correctly", () => {
+      const tree = buildJsonTree(testData);
+      const expandedNodes = new Set(["root", "address"]);
+      const flattened = flattenNodes(tree, expandedNodes);
+
+      // Should include root, its children, and address children
+      expect(flattened.length).toBeGreaterThan(4);
+
+      // Check that closing brackets are included
+      const closingNodes = flattened.filter((node) =>
+        node.id.endsWith("_closing"),
+      );
+      expect(closingNodes.length).toBeGreaterThan(0);
+    });
+
+    it("should respect collapsed state", () => {
+      const tree = buildJsonTree(testData);
+      const expandedNodes = new Set(["root"]); // Only root expanded
+      const flattened = flattenNodes(tree, expandedNodes);
+
+      // Should only show root's direct children, not nested ones
+      const addressChildren = flattened.filter(
+        (node) => node.path.path.length > 1 && node.path.path[0] === "address",
+      );
+      expect(addressChildren.length).toBe(0); // Address should be collapsed
+    });
+  });
+
+  describe("handleNavigation", () => {
+    it("should handle move_down action", () => {
+      const state = initializeCollapsibleState(testData);
+      const result = handleNavigation(state, { type: "move_down" });
+
+      if (result.newState.cursorPosition && state.cursorPosition) {
+        expect(result.newState.cursorPosition.lineIndex).toBeGreaterThanOrEqual(
+          state.cursorPosition.lineIndex,
+        );
+      }
+    });
+
+    it("should handle move_up action", () => {
+      const state = initializeCollapsibleState(testData);
+      // First move down, then test move up
+      const downResult = handleNavigation(state, { type: "move_down" });
+      const upResult = handleNavigation(downResult.newState, {
+        type: "move_up",
+      });
+
+      if (
+        upResult.newState.cursorPosition &&
+        downResult.newState.cursorPosition
+      ) {
+        expect(upResult.newState.cursorPosition.lineIndex).toBeLessThanOrEqual(
+          downResult.newState.cursorPosition.lineIndex,
+        );
+      }
+    });
+
+    it("should handle toggle_node action", () => {
+      const state = initializeCollapsibleState(testData);
+
+      // Find a collapsible node
+      const collapsibleNode = Array.from(state.nodes.values()).find(
+        (node) => node.isCollapsible,
+      );
+      if (collapsibleNode) {
+        // Position cursor on the collapsible node
+        state.cursorPosition = { nodeId: collapsibleNode.id, lineIndex: 0 };
+
+        const result = handleNavigation(state, { type: "toggle_node" });
+
+        // Node should be collapsed now
+        expect(result.newState.expandedNodes.has(collapsibleNode.id)).toBe(
+          false,
+        );
+      }
+    });
+  });
+
+  describe("formatCollapsedNode", () => {
+    it("should format collapsed nodes correctly", () => {
+      const objectNode = buildJsonTree({ a: 1, b: 2 });
+      const arrayNode = buildJsonTree([1, 2, 3]);
+
+      expect(formatCollapsedNode(objectNode)).toBe("{...}");
+      expect(formatCollapsedNode(arrayNode)).toBe("[...]");
+
+      const primitiveNode = buildJsonTree("string");
+      expect(formatCollapsedNode(primitiveNode)).toBe("");
+    });
+  });
+
+  describe("getNodeDisplayText", () => {
+    it("should generate correct display text for expanded nodes", () => {
+      const tree = buildJsonTree(testData);
+      const displayText = getNodeDisplayText(tree, true);
+
+      expect(displayText).toBe("{"); // Root object opening
+    });
+
+    it("should generate correct display text for collapsed nodes", () => {
+      const tree = buildJsonTree(testData);
+      const displayText = getNodeDisplayText(tree, false);
+
+      expect(displayText).toBe("{...}"); // Collapsed object
+    });
+
+    it("should generate correct display text for primitive values", () => {
+      const tree = buildJsonTree(testData);
+      const nameNode = tree.children?.find(
+        (child) => child.path.key === "name",
+      );
+
+      if (nameNode) {
+        const displayText = getNodeDisplayText(nameNode, true);
+        expect(displayText).toContain('"name": "John"');
+      }
+    });
+
+    it("should handle closing bracket nodes", () => {
+      const closingNode = {
+        id: "test_closing",
+        path: { type: "object" as const, path: [] },
+        value: "}",
+        type: "primitive" as const,
+        level: 0,
+        isCollapsible: false,
+        isCollapsed: false,
+      };
+
+      const displayText = getNodeDisplayText(closingNode, true);
+      expect(displayText).toBe("}");
+    });
+  });
+});

--- a/src/utils/collapsibleJson.test.ts
+++ b/src/utils/collapsibleJson.test.ts
@@ -9,7 +9,7 @@ import {
   handleNavigation,
   initializeCollapsibleState,
   isCollapsible,
-} from "./collapsibleJson";
+} from "./collapsibleJson.js";
 
 describe("collapsibleJson", () => {
   const testData = {

--- a/src/utils/collapsibleJson.ts
+++ b/src/utils/collapsibleJson.ts
@@ -1,0 +1,405 @@
+/**
+ * Utilities for managing collapsible JSON structure
+ */
+
+import type {
+  CollapsibleState,
+  CursorPosition,
+  JsonNode,
+  JsonPath,
+  NavigationAction,
+  NavigationResult,
+} from "../types/collapsible";
+import type { JsonValue } from "../types/index";
+
+/**
+ * Generate a unique ID for a JSON node based on its path
+ */
+export function generateNodeId(path: (string | number)[]): string {
+  return path.length === 0 ? "root" : path.join(".");
+}
+
+/**
+ * Determine the type of a JSON value
+ */
+export function getValueType(
+  value: JsonValue,
+): "object" | "array" | "primitive" {
+  if (value === null || value === undefined) return "primitive";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "object") return "object";
+  return "primitive";
+}
+
+/**
+ * Check if a value can be collapsed (objects and arrays with content)
+ */
+export function isCollapsible(value: JsonValue): boolean {
+  const type = getValueType(value);
+  if (type === "primitive") return false;
+
+  if (type === "array") return Array.isArray(value) && value.length > 0;
+  if (type === "object")
+    return value && typeof value === "object" && Object.keys(value).length > 0;
+
+  return false;
+}
+
+/**
+ * Convert JSON data to a tree of JsonNode objects
+ */
+export function buildJsonTree(
+  data: JsonValue,
+  path: (string | number)[] = [],
+  level: number = 0,
+  parent?: JsonNode,
+): JsonNode {
+  const nodeId = generateNodeId(path);
+  const valueType = getValueType(data);
+  const canCollapse = isCollapsible(data);
+
+  const jsonPath: JsonPath = {
+    type:
+      path.length === 0
+        ? "root"
+        : Array.isArray(parent?.value)
+          ? "array"
+          : "object",
+    key: path.length > 0 ? path[path.length - 1] : undefined,
+    path: [...path],
+  };
+
+  const node: JsonNode = {
+    id: nodeId,
+    path: jsonPath,
+    value: data,
+    type: valueType,
+    level,
+    isCollapsible: canCollapse,
+    isCollapsed: false, // Start expanded by default
+    parent,
+  };
+
+  // Build children for objects and arrays
+  if (valueType === "object" && data && typeof data === "object") {
+    node.children = Object.entries(data).map(([key, value]) =>
+      buildJsonTree(value, [...path, key], level + 1, node),
+    );
+  } else if (valueType === "array" && Array.isArray(data)) {
+    node.children = data.map((value, index) =>
+      buildJsonTree(value, [...path, index], level + 1, node),
+    );
+  }
+
+  return node;
+}
+
+/**
+ * Flatten the tree into a list of visible nodes (respecting collapsed state)
+ */
+export function flattenNodes(
+  root: JsonNode,
+  expandedNodes: Set<string>,
+): JsonNode[] {
+  const result: JsonNode[] = [];
+
+  function traverse(node: JsonNode) {
+    result.push(node);
+
+    // Only traverse children if the node is expanded (or not collapsible)
+    if (node.children && (!node.isCollapsible || expandedNodes.has(node.id))) {
+      for (const child of node.children) {
+        traverse(child);
+      }
+
+      // Add a closing bracket node for expanded objects/arrays
+      if (node.isCollapsible && expandedNodes.has(node.id)) {
+        const closingNode: JsonNode = {
+          id: `${node.id}_closing`,
+          path: { ...node.path },
+          value: node.type === "object" ? "}" : "]",
+          type: "primitive",
+          level: node.level,
+          isCollapsible: false,
+          isCollapsed: false,
+          parent: node.parent,
+        };
+        result.push(closingNode);
+      }
+    }
+  }
+
+  traverse(root);
+  return result;
+}
+
+/**
+ * Initialize collapsible state from JSON data
+ */
+export function initializeCollapsibleState(data: JsonValue): CollapsibleState {
+  const rootNode = buildJsonTree(data);
+  const nodes = new Map<string, JsonNode>();
+  const expandedNodes = new Set<string>();
+
+  // Collect all nodes and mark them as expanded by default
+  function collectNodes(node: JsonNode) {
+    nodes.set(node.id, node);
+    if (node.isCollapsible) {
+      expandedNodes.add(node.id);
+    }
+    if (node.children) {
+      for (const child of node.children) {
+        collectNodes(child);
+      }
+    }
+  }
+
+  collectNodes(rootNode);
+
+  const flattenedNodes = flattenNodes(rootNode, expandedNodes);
+  const cursorPosition: CursorPosition | null =
+    flattenedNodes.length > 0
+      ? { nodeId: flattenedNodes[0].id, lineIndex: 0 }
+      : null;
+
+  return {
+    nodes,
+    expandedNodes,
+    cursorPosition,
+    flattenedNodes,
+  };
+}
+
+/**
+ * Handle navigation actions and update state
+ */
+export function handleNavigation(
+  state: CollapsibleState,
+  action: NavigationAction,
+): NavigationResult {
+  const newState = { ...state };
+  let scrollToLine: number | undefined;
+
+  switch (action.type) {
+    case "move_up": {
+      if (!newState.cursorPosition) break;
+
+      const currentIndex = newState.flattenedNodes.findIndex(
+        (node) => node.id === newState.cursorPosition?.nodeId,
+      );
+
+      if (currentIndex > 0) {
+        const newNode = newState.flattenedNodes[currentIndex - 1];
+        newState.cursorPosition = {
+          nodeId: newNode.id,
+          lineIndex: currentIndex - 1,
+        };
+        scrollToLine = currentIndex - 1;
+      }
+      break;
+    }
+
+    case "move_down": {
+      if (!newState.cursorPosition) break;
+
+      const currentIndex = newState.flattenedNodes.findIndex(
+        (node) => node.id === newState.cursorPosition?.nodeId,
+      );
+
+      if (currentIndex < newState.flattenedNodes.length - 1) {
+        const newNode = newState.flattenedNodes[currentIndex + 1];
+        newState.cursorPosition = {
+          nodeId: newNode.id,
+          lineIndex: currentIndex + 1,
+        };
+        scrollToLine = currentIndex + 1;
+      }
+      break;
+    }
+
+    case "toggle_node": {
+      if (!newState.cursorPosition) break;
+
+      const currentNode = newState.nodes.get(newState.cursorPosition.nodeId);
+      if (!currentNode || !currentNode.isCollapsible) break;
+
+      // Toggle expanded state
+      newState.expandedNodes = new Set(state.expandedNodes);
+      if (newState.expandedNodes.has(currentNode.id)) {
+        newState.expandedNodes.delete(currentNode.id);
+      } else {
+        newState.expandedNodes.add(currentNode.id);
+      }
+
+      // Rebuild flattened nodes
+      const rootNode = Array.from(newState.nodes.values()).find(
+        (n) => n.path.path.length === 0,
+      );
+      if (rootNode) {
+        newState.flattenedNodes = flattenNodes(
+          rootNode,
+          newState.expandedNodes,
+        );
+
+        // Update cursor line index
+        const newIndex = newState.flattenedNodes.findIndex(
+          (node) => node.id === newState.cursorPosition?.nodeId,
+        );
+        if (newIndex >= 0) {
+          newState.cursorPosition.lineIndex = newIndex;
+          scrollToLine = newIndex;
+        }
+      }
+      break;
+    }
+
+    case "expand_all": {
+      newState.expandedNodes = new Set();
+      for (const node of newState.nodes.values()) {
+        if (node.isCollapsible) {
+          newState.expandedNodes.add(node.id);
+        }
+      }
+
+      const rootNode = Array.from(newState.nodes.values()).find(
+        (n) => n.path.path.length === 0,
+      );
+      if (rootNode) {
+        newState.flattenedNodes = flattenNodes(
+          rootNode,
+          newState.expandedNodes,
+        );
+
+        // Update cursor position
+        if (newState.cursorPosition) {
+          const newIndex = newState.flattenedNodes.findIndex(
+            (node) => node.id === newState.cursorPosition?.nodeId,
+          );
+          if (newIndex >= 0) {
+            newState.cursorPosition.lineIndex = newIndex;
+          }
+        }
+      }
+      break;
+    }
+
+    case "collapse_all": {
+      newState.expandedNodes = new Set();
+
+      const rootNode = Array.from(newState.nodes.values()).find(
+        (n) => n.path.path.length === 0,
+      );
+      if (rootNode) {
+        newState.flattenedNodes = flattenNodes(
+          rootNode,
+          newState.expandedNodes,
+        );
+
+        // Move cursor to root if current node is not visible
+        if (newState.cursorPosition) {
+          const isVisible = newState.flattenedNodes.some(
+            (node) => node.id === newState.cursorPosition?.nodeId,
+          );
+
+          if (!isVisible && rootNode) {
+            newState.cursorPosition = {
+              nodeId: rootNode.id,
+              lineIndex: 0,
+            };
+            scrollToLine = 0;
+          } else {
+            const newIndex = newState.flattenedNodes.findIndex(
+              (node) => node.id === newState.cursorPosition?.nodeId,
+            );
+            if (newIndex >= 0) {
+              newState.cursorPosition.lineIndex = newIndex;
+            }
+          }
+        }
+      }
+      break;
+    }
+  }
+
+  return { newState, scrollToLine };
+}
+
+/**
+ * Format a collapsed node for display
+ */
+export function formatCollapsedNode(node: JsonNode): string {
+  if (!node.isCollapsible) {
+    return "";
+  }
+
+  if (node.type === "object") {
+    const keys = node.children
+      ? node.children.length
+      : node.value && typeof node.value === "object"
+        ? Object.keys(node.value).length
+        : 0;
+    return keys > 0 ? `{...}` : "{}";
+  }
+
+  if (node.type === "array") {
+    const length = node.children
+      ? node.children.length
+      : Array.isArray(node.value)
+        ? node.value.length
+        : 0;
+    return length > 0 ? `[...]` : "[]";
+  }
+
+  return "";
+}
+
+/**
+ * Get the display text for a node
+ */
+export function getNodeDisplayText(
+  node: JsonNode,
+  isExpanded: boolean,
+): string {
+  const indent = "  ".repeat(node.level);
+  let prefix = "";
+  let suffix = "";
+
+  // Handle closing bracket nodes specially
+  if (node.id.endsWith("_closing")) {
+    return `${indent}${node.value}`;
+  }
+
+  // Add key for object properties and array indices
+  if (node.path.key !== undefined) {
+    if (node.path.type === "object") {
+      prefix = `"${node.path.key}": `;
+    } else if (node.path.type === "array") {
+      // For arrays, we might want to show index or just the value
+      prefix = "";
+    }
+  }
+
+  // Handle different value types
+  if (node.type === "primitive") {
+    const value = node.value;
+    if (typeof value === "string") {
+      suffix = `"${value}"`;
+    } else if (value === null) {
+      suffix = "null";
+    } else {
+      suffix = String(value);
+    }
+  } else if (node.isCollapsible && !isExpanded) {
+    // Show collapsed representation
+    suffix = formatCollapsedNode(node);
+  } else {
+    // Expanded object or array - show opening bracket
+    if (node.type === "object") {
+      suffix = "{";
+    } else if (node.type === "array") {
+      suffix = "[";
+    }
+  }
+
+  return `${indent}${prefix}${suffix}`;
+}

--- a/src/utils/collapsibleJson.ts
+++ b/src/utils/collapsibleJson.ts
@@ -9,8 +9,8 @@ import type {
   JsonPath,
   NavigationAction,
   NavigationResult,
-} from "../types/collapsible";
-import type { JsonValue } from "../types/index";
+} from "../types/collapsible.js";
+import type { JsonValue } from "../types/index.js";
 
 /**
  * Generate a unique ID for a JSON node based on its path
@@ -240,9 +240,7 @@ export function handleNavigation(
       }
 
       // Rebuild flattened nodes
-      const rootNode = Array.from(newState.nodes.values()).find(
-        (n) => n.path.path.length === 0,
-      );
+      const rootNode = newState.nodes.get("root");
       if (rootNode) {
         newState.flattenedNodes = flattenNodes(
           rootNode,
@@ -269,9 +267,7 @@ export function handleNavigation(
         }
       }
 
-      const rootNode = Array.from(newState.nodes.values()).find(
-        (n) => n.path.path.length === 0,
-      );
+      const rootNode = newState.nodes.get("root");
       if (rootNode) {
         newState.flattenedNodes = flattenNodes(
           rootNode,
@@ -294,9 +290,7 @@ export function handleNavigation(
     case "collapse_all": {
       newState.expandedNodes = new Set();
 
-      const rootNode = Array.from(newState.nodes.values()).find(
-        (n) => n.path.path.length === 0,
-      );
+      const rootNode = newState.nodes.get("root");
       if (rootNode) {
         newState.flattenedNodes = flattenNodes(
           rootNode,
@@ -410,4 +404,23 @@ export function getNodeDisplayText(
   }
 
   return `${indent}${prefix}${suffix}`;
+}
+
+/**
+ * Helper function to check if a node can be toggled
+ */
+export function canToggleNode(
+  state: CollapsibleState,
+  nodeId: string,
+): boolean {
+  const node = state.nodes.get(nodeId);
+  return node ? node.isCollapsible : false;
+}
+
+/**
+ * Helper function to get current cursor node
+ */
+export function getCurrentCursorNode(state: CollapsibleState) {
+  if (!state.cursorPosition) return null;
+  return state.nodes.get(state.cursorPosition.nodeId) || null;
 }

--- a/src/utils/syntaxHighlight.ts
+++ b/src/utils/syntaxHighlight.ts
@@ -121,7 +121,7 @@ export function parseKeyValueLine(line: string): {
   const afterColon = line.substring(colonIndex);
 
   const valueMatch = afterColon.match(/:\s*(.+?)(?:,\s*)?$/);
-  const value = valueMatch ? valueMatch[1] : afterColon.substring(1).trim();
+  const value = valueMatch?.[1] ?? afterColon.substring(1).trim();
   const isStructuralValue = value === "{" || value === "[";
 
   return { beforeColon, afterColon, value, isStructuralValue };


### PR DESCRIPTION
## Summary
This PR implements a comprehensive collapsible JSON viewer that allows users to navigate JSON data with cursor movement and expand/collapse objects and arrays interactively.

### ✨ New Features
- **Cursor Navigation**: Use `j`/`k` keys to move cursor up/down through JSON nodes
- **Interactive Expand/Collapse**: Press `Enter` to toggle expansion of objects and arrays  
- **Visual Collapsed State**: Collapsed objects display as `{...}` and arrays as `[...]`
- **Mode Toggle**: Press `C` to switch between normal and collapsible viewing modes
- **Cursor Highlighting**: Visual feedback shows current cursor position with background color

### 🏗️ Implementation Details

#### New Components & Types
- **`CollapsibleJsonViewer`**: React component with forwardRef pattern for navigation
- **Complete type system**: TypeScript interfaces for JSON nodes, cursor position, and navigation
- **Tree data structure**: Efficient JSON tree building with proper node flattening

#### Technical Features
- **Search Integration**: Full compatibility with existing search functionality using token-based highlighting
- **Performance Optimized**: Memoized calculations and O(1) search result lookups  
- **Memory Efficient**: Tree flattening respects collapsed state to minimize visible nodes
- **Keyboard Handling**: Comprehensive navigation with proper boundary checking

### 🧪 Test Coverage
- **15 new test cases** covering all utility functions
- Navigation, tree building, and display formatting thoroughly tested
- **All 231 existing tests continue to pass**

### 🎮 User Experience
- **Status Bar Updates**: Different help text displayed for collapsible mode
- **Seamless Integration**: Works with existing search, line numbers, and debug features
- **Intuitive Controls**: Familiar vim-style navigation (j/k/Enter)

### 📋 Usage
1. Press `C` to enter collapsible mode
2. Use `j`/`k` to navigate up/down through JSON nodes
3. Press `Enter` on objects/arrays to expand/collapse them
4. Collapsed items show as `{...}` or `[...]`
5. Press `C` again to return to normal mode

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a collapsible mode for JSON viewing, allowing users to expand and collapse nodes interactively in the terminal UI.
  * Added keyboard navigation for collapsible mode, including node expansion/collapse and cursor movement.
  * Integrated search highlighting within the collapsible viewer.
  * Added a keybinding to toggle collapsible mode.

* **Enhancements**
  * Status bar now displays context-sensitive help based on the current viewing mode.

* **Tests**
  * Added comprehensive tests for collapsible JSON tree navigation and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->