### PR TITLE
feat: remove minLength and maxLength from Schema Mode output

### DIFF
--- a/src/features/schema/utils/schemaUtils.ts
+++ b/src/features/schema/utils/schemaUtils.ts
@@ -101,9 +101,6 @@ function inferType(value: JsonValue): JsonSchemaProperty {
       schema.format = "uuid";
     }
 
-    schema.minLength = value.length;
-    schema.maxLength = value.length;
-
     return schema;
   }
 


### PR DESCRIPTION
## Summary
- Remove automatic minLength/maxLength generation for string properties in Schema Mode
- Clean up schema output by excluding redundant length constraints
- Maintain all other schema functionality while reducing verbosity

## Changes
- **Schema Generation**: Remove minLength/maxLength properties from string type inference
- **Preserved Functionality**: Keep format detection (email, uri, date-time, uuid) intact
- **Cleaner Output**: Generated schemas are more concise and focused on essential constraints

## Before
```json
{
  "name": {
    "type": "string",
    "minLength": 8,
    "maxLength": 8
  }
}
```

## After
```json
{
  "name": {
    "type": "string"
  }
}
```

## Implementation Details
- Modified `inferType()` function in `src/features/schema/utils/schemaUtils.ts`
- Removed lines that set `minLength` and `maxLength` based on string value length
- All other schema generation functionality remains unchanged

## Test Plan
- [x] Verify minLength/maxLength are not generated for string properties
- [x] Confirm format detection still works for email, URI, date-time, UUID
- [x] Validate schema utilities tests pass
- [x] Test schema generation with various string types
- [x] Ensure TypeScript type safety is maintained

🤖 Generated with [Claude Code](https://claude.ai/code)